### PR TITLE
Fix node ports for site instances

### DIFF
--- a/stages/prod/kustomization.yaml
+++ b/stages/prod/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
   patch: |-
     - op: replace
       path: /spec/ports/0/nodePort
-      value: 30083
+      value: 32082

--- a/stages/test/kustomization.yaml
+++ b/stages/test/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
   patch: |-
     - op: replace
       path: /spec/ports/0/nodePort
-      value: 30081
+      value: 32080

--- a/stages/uat/kustomization.yaml
+++ b/stages/uat/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
   patch: |-
     - op: replace
       path: /spec/ports/0/nodePort
-      value: 30082
+      value: 32081


### PR DESCRIPTION
Doing the quickstart, noticed that sites weren't accessible:

https://docs.kargo.io/quickstart/

See how kind cluster is created:

```

kind create cluster \
  --wait 120s \
  --config - <<EOF
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: kargo-quickstart
nodes:
- extraPortMappings:
  - containerPort: 31443 # Argo CD dashboard
    hostPort: 31443
  - containerPort: 31444 # Kargo dashboard
    hostPort: 31444
  - containerPort: 31445 # External webhooks server
    hostPort: 31445
  - containerPort: 32080 # test application instance
    hostPort: 32080
  - containerPort: 32081 # UAT application instance
    hostPort: 32081
  - containerPort: 32082 # prod application instance
    hostPort: 32082
  
EOF
```

https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/kind.sh
Same goes for k3d:
https://raw.githubusercontent.com/akuity/kargo/main/hack/quickstart/k3d.sh